### PR TITLE
Add IntervalPublisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -9,11 +9,13 @@ let package = Package(
   products: [
     .library(name: "TFFPublishers", targets: ["TFFPublishers"]),
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/glessard/CurrentQoS", from: "1.2.0"),
+  ],
   targets: [
     .target(
       name: "TFFPublishers",
-      dependencies: []),
+      dependencies: ["CurrentQoS"]),
     .testTarget(
       name: "TFFPublishersTests",
       dependencies: ["TFFPublishers"]),

--- a/Sources/TFFPublishers/IntervalPublisher.swift
+++ b/Sources/TFFPublishers/IntervalPublisher.swift
@@ -1,0 +1,157 @@
+//  IntervalPublisher.swift
+//  
+//  Copyright © 2020 Guillaume Lessard. All rights reserved
+
+import Combine
+
+public struct IntervalPublisher<P: Publisher, SchedulerType: Scheduler>: Publisher
+{
+  public typealias Output =  P.Output
+  public typealias Failure = P.Failure
+  public typealias Interval = SchedulerType.SchedulerTimeType
+  public typealias Comparator = (Output?, Output) -> Interval
+
+  private var publisher: Publishers.ReceiveOn<P, SchedulerType>
+  private var scheduler: SchedulerType
+  private var interval: Comparator
+
+  public init(publisher: P, scheduler: SchedulerType, interval: @escaping (_ previous: Output?, _ current: Output) -> Interval)
+  {
+    self.publisher = publisher.receive(on: scheduler)
+    self.scheduler = scheduler
+    self.interval = interval
+  }
+
+  public func receive<Downstream: Subscriber>(subscriber: Downstream)
+    where Downstream.Input == Output, Downstream.Failure == Failure
+  {
+    let inner = Inner<Downstream, SchedulerType>(downstream: subscriber, scheduler: scheduler, interval: interval)
+    subscriber.receive(subscription: inner)
+    publisher.subscribe(inner)
+  }
+}
+
+public struct ConstantIntervalPublisher<P: Publisher, SchedulerType: Scheduler>: Publisher
+{
+  public typealias Output =  P.Output
+  public typealias Failure = P.Failure
+  public typealias Interval = SchedulerType.SchedulerTimeType
+
+  private var publisher: IntervalPublisher<P, SchedulerType>
+
+  public init(publisher: P, scheduler: SchedulerType, interval: Interval)
+  {
+    self.publisher = IntervalPublisher(publisher: publisher, scheduler: scheduler, interval: { _, _ in interval })
+  }
+
+  public func receive<Downstream: Subscriber>(subscriber: Downstream)
+    where Downstream.Input == Output, Downstream.Failure == Failure
+  {
+    publisher.receive(subscriber: subscriber)
+  }
+}
+
+extension IntervalPublisher where Output: Equatable
+{
+  public init(publisher: P, scheduler: SchedulerType, interval: @escaping (_ areEqual: Bool) -> Interval)
+  {
+    let c: Comparator = { interval($0 == $1) }
+    self.init(publisher: publisher, scheduler: scheduler, interval: c)
+  }
+}
+
+extension IntervalPublisher
+{
+  fileprivate final class Inner<Downstream: Subscriber, SchedulerType: Scheduler>: Subscriber, Subscription
+  {
+    typealias Input =   Downstream.Input
+    typealias Failure = Downstream.Failure
+    typealias Interval = SchedulerType.SchedulerTimeType
+    typealias Comparator = (Input?, Input) -> Interval
+
+    private let interval: Comparator
+    private let scheduler: SchedulerType
+
+    private let downstream: Downstream
+    private var subscription: Subscription?
+
+    private let lock = Lock.allocate()
+    private var demand = Subscribers.Demand.none
+    private var previous: Input? = nil
+
+    fileprivate init(downstream: Downstream, scheduler: SchedulerType, interval: @escaping Comparator)
+    {
+      self.downstream = downstream
+      self.scheduler = scheduler
+      self.interval = interval
+    }
+
+    deinit {
+      subscription?.cancel()
+      lock.deallocate()
+    }
+
+    // MARK: Subscription stuff
+
+    func request(_ demand: Subscribers.Demand)
+    {
+      lock.lock()
+      self.demand += demand
+      let upstream = subscription
+      lock.unlock()
+      upstream?.request(demand)
+    }
+
+    func cancel()
+    {
+      lock.lock()
+      demand = .none
+      let upstream = subscription
+      subscription = nil
+      lock.unlock()
+      upstream?.cancel()
+    }
+
+    // MARK: Subscriber stuff
+
+    func receive(subscription: Subscription)
+    {
+      lock.lock()
+      assert(self.subscription == nil)
+      self.subscription = subscription
+      let demand = self.demand
+      lock.unlock()
+      if demand > 0
+      {
+        subscription.request(demand)
+      }
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand
+    {
+      let additional = downstream.receive(input)
+      lock.lock()
+      demand += additional
+      if demand > 0 { demand -= 1 }
+      let upstream = (demand > 0) ? subscription : nil
+      let prev = previous
+      previous = input
+      lock.unlock()
+      if let upstream = upstream
+      {
+        let delay = interval(prev, input)
+        scheduler.schedule(after: delay, { upstream.request(.max(1)) })
+      }
+      return .none
+    }
+
+    func receive(completion: Subscribers.Completion<Downstream.Failure>)
+    {
+      lock.lock()
+      subscription = nil
+      demand = .none
+      lock.unlock()
+      downstream.receive(completion: completion)
+    }
+  }
+}

--- a/Sources/TFFPublishers/IntervalPublisher.swift
+++ b/Sources/TFFPublishers/IntervalPublisher.swift
@@ -147,7 +147,7 @@ extension IntervalPublisher
       self.subscription = subscription
       if demand > 0
       {
-        subscription.request(demand)
+        subscription.request(.max(1))
       }
     }
 
@@ -157,13 +157,14 @@ extension IntervalPublisher
       let prev = previous
       previous = input
 
-      guard demand > 0 else { return .none }
-
-      demand -= 1
-      if let upstream = subscription, demand >= 0
+      if demand > 0
       {
-        let onset = scheduler.now.advanced(by: interval(prev, input))
-        scheduler.schedule(after: onset, { upstream.request(.max(1)) })
+        demand -= 1
+        if let upstream = subscription, demand >= 0
+        {
+          let onset = scheduler.now.advanced(by: interval(prev, input))
+          scheduler.schedule(after: onset, { upstream.request(.max(1)) })
+        }
       }
       return .none
     }

--- a/Sources/TFFPublishers/IntervalPublisher.swift
+++ b/Sources/TFFPublishers/IntervalPublisher.swift
@@ -5,6 +5,8 @@
 import Combine
 import Dispatch
 
+import CurrentQoS
+
 public struct IntervalPublisher<P: Publisher, SchedulerType: Scheduler>: Publisher
 {
   public typealias Output =  P.Output
@@ -42,13 +44,13 @@ public struct IntervalPublisher<P: Publisher, SchedulerType: Scheduler>: Publish
 extension IntervalPublisher
   where SchedulerType == DispatchQueue
 {
-  public init(publisher: P, qos: DispatchQoS, interval: @escaping (_ previous: Output?, _ current: Output) -> Interval)
+  public init(publisher: P, qos: DispatchQoS = .current, interval: @escaping (_ previous: Output?, _ current: Output) -> Interval)
   {
     let queue = DispatchQueue(label: #function, qos: qos)
     self.init(publisher: publisher, scheduler: queue, interval: interval)
   }
 
-  public init(publisher: P, qos: DispatchQoS, interval: @escaping (_ areEqual: Bool) -> Interval)
+  public init(publisher: P, qos: DispatchQoS = .current, interval: @escaping (_ areEqual: Bool) -> Interval)
     where Output: Equatable
   {
     let queue = DispatchQueue(label: #function, qos: qos)
@@ -79,7 +81,7 @@ public struct FixedIntervalPublisher<P: Publisher, SchedulerType: Scheduler>: Pu
 extension FixedIntervalPublisher
   where SchedulerType == DispatchQueue
 {
-  public init(publisher: P, qos: DispatchQoS, interval: Interval)
+  public init(publisher: P, qos: DispatchQoS = .current, interval: Interval)
   {
     let queue = DispatchQueue(label: #function, qos: qos)
     self.init(publisher: publisher, scheduler: queue, interval: interval)

--- a/Tests/TFFPublishersTests/IntervalPublisherTests.swift
+++ b/Tests/TFFPublishersTests/IntervalPublisherTests.swift
@@ -10,12 +10,12 @@ final class IntervalPublisherTests: XCTestCase
   {
     let count = 10
     let delay = 10
-    let p = FixedIntervalPublisher(publisher: PartialRangeFrom(0).publisher,
-                                   interval: .milliseconds(delay)).prefix(count+1)
+    let p = IntervalPublisher(publisher: PartialRangeFrom(0).publisher,
+                              interval: .milliseconds(delay)).prefix(count+1)
 
     let e = expectation(description: #function)
     let start = Date()
-    let c = p.sink(receiveCompletion: { _ in e.fulfill()}, receiveValue: { print($0) })
+    let c = p.sink(receiveCompletion: { _ in e.fulfill()}, receiveValue: { _ in })
 
     waitForExpectations(timeout: Double(count*delay)*0.1)
     c.cancel()

--- a/Tests/TFFPublishersTests/IntervalPublisherTests.swift
+++ b/Tests/TFFPublishersTests/IntervalPublisherTests.swift
@@ -6,6 +6,7 @@ import TFFPublishers
 
 final class IntervalPublisherTests: XCTestCase
 {
+#if swift(>=5.3)
   func testIntervalPublisher()
   {
     let count = 10
@@ -44,16 +45,22 @@ final class IntervalPublisherTests: XCTestCase
 
   func testIntervalPublisherWithMultipleClosureSyntax()
   {
-    #if swift(>=5.3)
-    let p = IntervalPublisher(publisher: repeatElement(0, count: 10).publisher) { .milliseconds($0 == $1 ? 0 : 1) }
+    var p = IntervalPublisher(publisher: repeatElement(0, count: 10).publisher) { .milliseconds($0 == $1 ? 0 : 1) }
               initialInterval: { _ in .milliseconds(10) }
+
+    p = IntervalPublisher(publisher: repeatElement(0, count: 10).publisher,
+                          interval: { .milliseconds($0 == $1 ? 0 : 1) }) { _ in .milliseconds(10) }
+
+#warning("Remove the following compilation condition after Swift 5.3 \"beta 4\"")
+#if swift(>=5.3.1)
+    p = IntervalPublisher(publisher: repeatElement(0, count: 10).publisher) { .milliseconds($0 == $1 ? 0 : 1) }
+#endif
 
     let e = expectation(description: #function)
     let c = p.sink { _ in e.fulfill() } receiveValue: { _ in }
 
     waitForExpectations(timeout: 0.1)
     c.cancel()
-    #endif
   }
 
   func testIntervalPublisherWithFixedInterval()
@@ -73,4 +80,5 @@ final class IntervalPublisherTests: XCTestCase
     let elapsed = Date().timeIntervalSince(start)
     XCTAssertGreaterThan(elapsed, Double(count*delay)*0.001)
   }
+#endif
 }

--- a/Tests/TFFPublishersTests/IntervalPublisherTests.swift
+++ b/Tests/TFFPublishersTests/IntervalPublisherTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import Combine
+import Dispatch
+
+import TFFPublishers
+
+final class IntervalPublisherTests: XCTestCase
+{
+  func testIntervalPublisher()
+  {
+    let count = 10
+    let delay = 10
+    let p = FixedIntervalPublisher(publisher: PartialRangeFrom(0).publisher,
+                                   interval: .milliseconds(delay)).prefix(count+1)
+
+    let e = expectation(description: #function)
+    let start = Date()
+    let c = p.sink(receiveCompletion: { _ in e.fulfill()}, receiveValue: { print($0) })
+
+    waitForExpectations(timeout: Double(count*delay)*0.1)
+    c.cancel()
+    let elapsed = Date().timeIntervalSince(start)
+    XCTAssertGreaterThan(elapsed, Double(count*delay)*0.001)
+  }
+}

--- a/Tests/TFFPublishersTests/IntervalPublisherTests.swift
+++ b/Tests/TFFPublishersTests/IntervalPublisherTests.swift
@@ -25,11 +25,12 @@ final class IntervalPublisherTests: XCTestCase
 
   func testIntervalPublisherWithInitialInterval()
   {
+    let delay = 10
     let p = IntervalPublisher(publisher: Range(1...2).publisher,
                               scheduler: DispatchQueue(label: #function),
                               initialValue: 0,
-                              interval: { .milliseconds($1 - ($0 ?? 0)) },
-                              initialInterval: { .milliseconds($0.map({ $0+1 }) ?? 0) })
+                              interval: { .milliseconds(($1 - ($0 ?? 0))*delay) },
+                              initialInterval: { .milliseconds($0.map({ ($0+1)*delay }) ?? 0) })
 
     let e = expectation(description: #function)
     let start = Date()
@@ -38,10 +39,10 @@ final class IntervalPublisherTests: XCTestCase
     waitForExpectations(timeout: 10.0)
     c.cancel()
     let elapsed = Date().timeIntervalSince(start)
-    XCTAssertGreaterThan(elapsed, 0.002)
+    XCTAssertGreaterThan(elapsed, Double(2*delay)*0.001)
   }
 
-  func testIntervalPublisherWithMultipleClosures()
+  func testIntervalPublisherWithMultipleClosureSyntax()
   {
     #if swift(>=5.3)
     let p = IntervalPublisher(publisher: repeatElement(0, count: 10).publisher) { .milliseconds($0 == $1 ? 0 : 1) }
@@ -57,17 +58,19 @@ final class IntervalPublisherTests: XCTestCase
 
   func testIntervalPublisherWithFixedInterval()
   {
-    let p = IntervalPublisher(publisher: Range(1...10).publisher,
+    let count = 10
+    let delay = 10
+    let p = IntervalPublisher(publisher: Range(0...count).publisher,
                               scheduler: DispatchQueue(label: #function),
-                              interval: .milliseconds(1))
+                              interval: .milliseconds(delay))
 
     let e = expectation(description: #function)
     let start = Date()
     let c = p.sink(receiveCompletion: { _ in e.fulfill() }, receiveValue: { _ in })
 
-    waitForExpectations(timeout: 10.0)
+    waitForExpectations(timeout: Double(count*delay)*0.1)
     c.cancel()
     let elapsed = Date().timeIntervalSince(start)
-    XCTAssertGreaterThan(elapsed, 0.010)
+    XCTAssertGreaterThan(elapsed, Double(count*delay)*0.001)
   }
 }

--- a/Tests/TFFPublishersTests/IntervalPublisherTests.swift
+++ b/Tests/TFFPublishersTests/IntervalPublisherTests.swift
@@ -22,4 +22,52 @@ final class IntervalPublisherTests: XCTestCase
     let elapsed = Date().timeIntervalSince(start)
     XCTAssertGreaterThan(elapsed, Double(count*delay)*0.001)
   }
+
+  func testIntervalPublisherWithInitialInterval()
+  {
+    let p = IntervalPublisher(publisher: Range(1...2).publisher,
+                              scheduler: DispatchQueue(label: #function),
+                              initialValue: 0,
+                              interval: { .milliseconds($1 - ($0 ?? 0)) },
+                              initialInterval: { .milliseconds($0.map({ $0+1 }) ?? 0) })
+
+    let e = expectation(description: #function)
+    let start = Date()
+    let c = p.sink(receiveCompletion: { _ in e.fulfill() }, receiveValue: { _ in })
+
+    waitForExpectations(timeout: 10.0)
+    c.cancel()
+    let elapsed = Date().timeIntervalSince(start)
+    XCTAssertGreaterThan(elapsed, 0.002)
+  }
+
+  func testIntervalPublisherWithMultipleClosures()
+  {
+    #if swift(>=5.3)
+    let p = IntervalPublisher(publisher: repeatElement(0, count: 10).publisher) { .milliseconds($0 == $1 ? 0 : 1) }
+              initialInterval: { _ in .milliseconds(10) }
+
+    let e = expectation(description: #function)
+    let c = p.sink { _ in e.fulfill() } receiveValue: { _ in }
+
+    waitForExpectations(timeout: 0.1)
+    c.cancel()
+    #endif
+  }
+
+  func testIntervalPublisherWithFixedInterval()
+  {
+    let p = IntervalPublisher(publisher: Range(1...10).publisher,
+                              scheduler: DispatchQueue(label: #function),
+                              interval: .milliseconds(1))
+
+    let e = expectation(description: #function)
+    let start = Date()
+    let c = p.sink(receiveCompletion: { _ in e.fulfill() }, receiveValue: { _ in })
+
+    waitForExpectations(timeout: 10.0)
+    c.cancel()
+    let elapsed = Date().timeIntervalSince(start)
+    XCTAssertGreaterThan(elapsed, 0.010)
+  }
 }


### PR DESCRIPTION
- it depends on Swift 5.3, because of compiler crashes with earlier versions.
- it might be possible to make it work with Swift 5.1 and up, but I couldn't find a solution to make it happen.